### PR TITLE
Image upload bug fix

### DIFF
--- a/src/containers/community/CommunityEditor.js
+++ b/src/containers/community/CommunityEditor.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { some, get, omit, toPairs } from 'lodash'
 import {
   CREATE_COMMUNITY,
+  UPLOAD_IMAGE,
   createCommunity,
   navigate,
   resetCommunityValidation,
@@ -36,6 +37,7 @@ const categories = {
   let validating = some(communityValidation.pending)
   let { community, errors } = communityEditor
   let saving = pending[CREATE_COMMUNITY]
+  let uploadingImage = !!pending[UPLOAD_IMAGE]
 
   if (!errors) errors = {}
   errors.nameUsed = get(communityValidation, 'name.unique') === false
@@ -46,11 +48,12 @@ const categories = {
   if (!community.avatar_url) community.avatar_url = defaultAvatar
   if (!community.banner_url) community.banner_url = defaultBanner
 
-  return {community, errors, validating, saving}
+  return {community, errors, validating, saving, uploadingImage}
 })
 export default class CommunityEditor extends React.Component {
   static propTypes = {
     saving: bool,
+    uploadingImage: bool,
     validating: bool,
     errors: object,
     dispatch: func,
@@ -191,8 +194,8 @@ export default class CommunityEditor extends React.Component {
   }
 
   render () {
-    let { validating, saving, community, errors } = this.props
-    let disableSubmit = some(omit(errors, 'server')) || validating || saving
+    let { validating, saving, uploadingImage, community, errors } = this.props
+    let disableSubmit = some(omit(errors, 'server')) || validating || saving || uploadingImage
 
     return <div id='community-editor' className='form-sections'>
       <h2>Create a community</h2>
@@ -313,7 +316,7 @@ export default class CommunityEditor extends React.Component {
           {errors.server || 'The information you provided has some errors; please see above.'}
         </p>}
         <button type='button' onClick={this.submit} disabled={disableSubmit}>
-          {validating || saving ? 'Please wait...' : 'Save'}
+          {validating || saving || uploadingImage ? 'Please wait...' : 'Save'}
         </button>
       </div>
 

--- a/src/containers/network/NetworkEditor.js
+++ b/src/containers/network/NetworkEditor.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { some, get, omit, filter, startsWith, contains } from 'lodash'
 import {
   CREATE_NETWORK,
+  UPLOAD_IMAGE,
   createNetwork,
   navigate,
   typeahead,
@@ -25,6 +26,7 @@ let typeaheadId = 'network_communities'
   let validating = some(networkValidation.pending)
   let { network, errors } = networkEditor
   let saving = pending[CREATE_NETWORK]
+  let uploadingImage = !!pending[UPLOAD_IMAGE]
 
   if (!errors) errors = {}
   errors.nameUsed = get(networkValidation, 'name.unique') === false
@@ -36,7 +38,7 @@ let typeaheadId = 'network_communities'
   if (!network.banner_url) network.banner_url = defaultBanner
 
   return {
-    network, errors, validating, saving,
+    network, errors, validating, saving, uploadingImage,
     currentUser: people.current,
     communityChoices: typeaheadMatches[typeaheadId] || []
   }
@@ -44,6 +46,7 @@ let typeaheadId = 'network_communities'
 export default class NetworkEditor extends React.Component {
   static propTypes = {
     saving: bool,
+    uploadingImage: bool,
     validating: bool,
     errors: object,
     dispatch: func,
@@ -209,9 +212,9 @@ export default class NetworkEditor extends React.Component {
   }
 
   render () {
-    let { validating, saving, network, errors, communityChoices } = this.props
+    let { validating, saving, uploadingImage, network, errors, communityChoices } = this.props
     let { communities } = network
-    let disableSubmit = some(omit(errors, 'server')) || validating || saving
+    let disableSubmit = some(omit(errors, 'server')) || validating || saving || uploadingImage
 
     return <div id='network-editor' className='form-sections'>
       <h2>Create a network</h2>
@@ -304,7 +307,7 @@ export default class NetworkEditor extends React.Component {
           {errors.server || 'The information you provided has some errors; please see above.'}
         </p>}
         <button type='button' onClick={this.submit} disabled={disableSubmit}>
-          {validating || saving ? 'Please wait...' : 'Save'}
+          {validating || saving || uploadingImage ? 'Please wait...' : 'Save'}
         </button>
       </div>
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -322,12 +322,12 @@ export default combineReducers({
         if (meta.subject === 'network-avatar') {
           return {
             ...state,
-            community: {...state.network, avatar_url: payload}
+            network: {...state.network, avatar_url: payload}
           }
         } else if (meta.subject === 'network-banner') {
           return {
             ...state,
-            community: {...state.network, banner_url: payload}
+            network: {...state.network, banner_url: payload}
           }
         }
     }


### PR DESCRIPTION
This fixes an issue in community and network creation where, if you upload an image and then immediately save the community/network, before the UPLOAD_IMAGE action has fired, you lose the image. 
Now you cannot save while UPLOAD_IMAGE is pending
