### PR TITLE
Run the name through sanitization to prevent name XSS issue

### DIFF
--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -22,7 +22,7 @@ const Comment = ({ comment, truncate, expand, community }, { dispatch, currentUs
   let text = present(sanitize(comment.text), {slug: get('slug', community)})
   const truncated = truncate && textLength(text) > truncatedLength
   if (truncated) text = truncateHtml(text, truncatedLength)
-  text = prependInP(text, `<a href='/u/${person.id}'><strong class='name'>${person.name}</strong></a>`)
+  text = prependInP(text, `<a href='/u/${person.id}'><strong class='name'>${sanitize(person.name)}</strong></a>`)
   const remove = () => window.confirm('Delete this comment? This cannot be undone.') &&
     dispatch(removeComment(comment.id))
 


### PR DESCRIPTION
Commit fixes a XSS injection site where your name can contain tags which are not stripped out. The only location found that displays the tags without escaping or sanitisation that was found was when displaying comments

<img width="652" alt="screen shot 2016-07-28 at 4 35 18 pm" src="https://cloud.githubusercontent.com/assets/5952729/17203253/aaacbd68-54e1-11e6-9cad-870409ee86f0.png">

---

<img width="684" alt="screen shot 2016-07-28 at 4 35 42 pm" src="https://cloud.githubusercontent.com/assets/5952729/17203255/ac9d65be-54e1-11e6-85f0-5837f75f7b7f.png">
