### PR TITLE
DMs: when scrolled up, be notified of new messages

### DIFF
--- a/css/threads.less
+++ b/css/threads.less
@@ -1,3 +1,5 @@
+@scroll-button-height: 36px;
+@scroll-button-width: 150px;
 
 .thread {
   display: flex;
@@ -42,6 +44,35 @@
     background-color: #FFF;
     border-bottom: 1px solid @post-border;
     padding: 10px 0;
+
+    .newMessagesNotify {
+      position: fixed;
+      background-color: @damian-red;
+      color: #FFF;
+      border-radius: 5px;
+      bottom: 65px;
+      left: 50%;
+      margin-left: -@scroll-button-width/2;
+      cursor: pointer;
+      line-height: @scroll-button-height;
+      border-radius: @scroll-button-height;
+      width: @scroll-button-width;
+      text-align: center;
+
+      &:after {
+        top: 100%;
+        left: 50%;
+        border: solid transparent;
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        pointer-events: none;
+        border-top-color: @damian-red;
+        border-width: 7px;
+        margin-left: -7px;
+      }
+    }
   }
 
   .message {

--- a/src/components/MessageSection.js
+++ b/src/components/MessageSection.js
@@ -4,11 +4,13 @@ const { array, bool, string, func, object } = React.PropTypes
 import cx from 'classnames'
 import Message from './Message'
 import { appendComment } from '../actions/comments'
+import { updatePostReadTime } from '../actions/posts'
 import { getSocket, socketUrl } from '../client/websockets'
 
 export default class MessageSection extends React.Component {
   static propTypes = {
-    messages: array
+    messages: array,
+    thread: object
   }
 
   static contextTypes = {
@@ -24,29 +26,42 @@ export default class MessageSection extends React.Component {
   }
 
   componentDidMount() {
-    this._scrollToBottom()  
+    this._scrollToBottom()
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    const messagesLength = this.props.messages.length
+    const oldMessagesLength = prevProps.messages.length
     const { scrolledUp } = this.state
-    if (!scrolledUp) this._scrollToBottom()
+    if (!scrolledUp && messagesLength !== oldMessagesLength) this._scrollToBottom()
   }
 
   _handleScroll(target) {
     const { scrolledUp } = this.state
-    const onBottom = target.scrollTop > target.scrollHeight - target.offsetHeight 
+    const onBottom = target.scrollTop > target.scrollHeight - target.offsetHeight
     if (!onBottom && !scrolledUp) this.setState({ scrolledUp: true })
-    else if (onBottom && scrolledUp) this.setState({ scrolledUp: false })
+    else if (onBottom && scrolledUp) {
+      this.setState({ scrolledUp: false })
+      this.markAsRead()
+    }
   }
 
   _scrollToBottom() {
     const div = this.refs['messageList']
     div.scrollTop = div.scrollHeight
+    this.markAsRead()
   }
 
-  render () {
-    let { messages } = this.props
+  markAsRead() {
+    const { thread } = this.props
+    const { dispatch } = this.context
+    dispatch(updatePostReadTime(thread.id))
+  }
+
+  render() {
+    let { messages, thread } = this.props
     const { currentUser } = this.context
+    const { scrolledUp } = this.state
     const throttledScroll = throttle(this._handleScroll.bind(this), 500, { trailing: true })
     const onScroll = (event) => {
       // must be done this way because of event pooling https://fb.me/react-event-pooling
@@ -56,13 +71,16 @@ export default class MessageSection extends React.Component {
 
     if (!messages) messages = []
     messages = sortBy(messages, m => m.created_at)
+    const latestMessage = messages.length && messages[messages.length - 1]
+    const latestFromOther = latestMessage && latestMessage.user_id !== currentUser.id
+    const newFromOther = latestFromOther && thread.last_read_at && new Date(latestMessage.created_at) > new Date(thread.last_read_at)
 
     return <div
              className={cx('messages-section', {empty: isEmpty(messages)})}
              ref='messageList'
              onScroll={onScroll}>
       {messages.map(m => <Message message={m} key={m.id}/>)}
+      { newFromOther && scrolledUp && <div className='newMessagesNotify' onClick={this._scrollToBottom.bind(this)}>New Messages</div> }
     </div>
   }
 }
-

--- a/src/components/Thread.js
+++ b/src/components/Thread.js
@@ -8,7 +8,6 @@ import MessageForm from './MessageForm'
 import A from './A'
 import PeopleTyping from './PeopleTyping'
 import { connect } from 'react-redux'
-
 import { onThreadPage, offThreadPage } from '../actions/threads'
 import { getComments } from '../models/post'
 import { getSocket, socketUrl } from '../client/websockets'

--- a/src/components/Thread.js
+++ b/src/components/Thread.js
@@ -8,7 +8,7 @@ import MessageForm from './MessageForm'
 import A from './A'
 import PeopleTyping from './PeopleTyping'
 import { connect } from 'react-redux'
-import { updatePostReadTime } from '../actions/posts'
+
 import { onThreadPage, offThreadPage } from '../actions/threads'
 import { getComments } from '../models/post'
 import { getSocket, socketUrl } from '../client/websockets'
@@ -30,7 +30,6 @@ export default class Thread extends React.Component {
   }
 
   setupForThread (post) {
-    this.markAsRead(post)
     this.props.dispatch(onThreadPage(post.id))
     if (this.socket) {
       this.socket.post(socketUrl(`/noo/post/${post.id}/subscribe`)) // for people typing
@@ -62,18 +61,13 @@ export default class Thread extends React.Component {
     }
   }
 
-  markAsRead (post) {
-    const { dispatch } = this.props
-    dispatch(updatePostReadTime(post.id))
-  }
-
   render () {
     const { post, messages } = this.props
     const classes = cx('thread')
 
     return <div className={classes}>
       <Header />
-      <MessageSection {...{messages}}/>
+      <MessageSection {...{messages}} thread={post}/>
       <PeopleTyping showNames/>
       <MessageForm postId={post.id} ref='form'/>
     </div>


### PR DESCRIPTION
Also updates 'last_read_at' for posts when the scrolling hits the bottom, including when user sends a message, and receives a message and is 'on the bottom'

Correlates stylistically with the '1 new post' indicator on post feeds

Question: is the language ok?

![screen shot 2016-11-04 at 9 28 32 am](https://cloud.githubusercontent.com/assets/1409121/20014158/126ced18-a273-11e6-9fd1-126863a6b749.png)
