### PR TITLE
Fetch the full community record for current community on Single Post …

### DIFF
--- a/src/containers/SinglePost.js
+++ b/src/containers/SinglePost.js
@@ -143,8 +143,10 @@ const setupPage = (store, id, query, action) => {
   return Promise.all([
     communityId !== currentCommunityId &&
       saveCurrentCommunityId(dispatch, communityId, !!currentUser),
+
     // Always load the full record for the current Community record
-    dispatch(fetchCommunity(communityId), {refresh: true}),
+    dispatch(fetchCommunity(communityId)),
+
     // when this page is clicked into from a post list, fetchPost will cause a
     // cache hit; however, there may be more comments than the 3 that were
     // included in the list, so we have to call fetchComments to retrieve the

--- a/src/containers/SinglePost.js
+++ b/src/containers/SinglePost.js
@@ -6,6 +6,7 @@ import { includes } from 'lodash'
 import { get, pick } from 'lodash/fp'
 import { FETCH_POST, navigate, notify, setMetaTags } from '../actions'
 import { fetchComments } from '../actions/comments'
+import { fetchCommunity } from '../actions/communities'
 import { fetchPost, unfollowPost } from '../actions/posts'
 import { saveCurrentCommunityId } from '../actions/util'
 import { ogMetaTags } from '../util'
@@ -142,7 +143,8 @@ const setupPage = (store, id, query, action) => {
   return Promise.all([
     communityId !== currentCommunityId &&
       saveCurrentCommunityId(dispatch, communityId, !!currentUser),
-
+    // Always load the full record for the current Community record
+    dispatch(fetchCommunity(communityId), {refresh: true}),
     // when this page is clicked into from a post list, fetchPost will cause a
     // cache hit; however, there may be more comments than the 3 that were
     // included in the list, so we have to call fetchComments to retrieve the


### PR DESCRIPTION
…so that navigation is correct

I think the simplest solution is best in this case. Take a look, happy to approach this differently. 

NOTE: It seems like UserProfile#show / edit also has some nav issues related to not necessarily having a "not in any community context"