### PR TITLE
improve ux for picking person and sending message

### DIFF
--- a/src/components/MessageToUserForm.js
+++ b/src/components/MessageToUserForm.js
@@ -18,7 +18,7 @@ const NEW_MESSAGE_ID = 'new'
     text: state.messageEdits[userId],
     newText: state.messageEdits[NEW_MESSAGE_ID]
   })
-})
+}, null, null, {withRef: true})
 export default class MessageToUserForm extends React.Component {
   static propTypes = {
     currentUser: object,
@@ -43,6 +43,10 @@ export default class MessageToUserForm extends React.Component {
     const modifierKey = window.navigator.platform.startsWith('Mac')
       ? 'Cmd' : 'Ctrl'
     this.setState({modifierKey})
+  }
+  
+  focus () {
+    this.refs.editor.focus()
   }
 
   componentWillReceiveProps (nextProps) {

--- a/src/components/PersonChooser.js
+++ b/src/components/PersonChooser.js
@@ -6,7 +6,7 @@ import { filter, get } from 'lodash/fp'
 import { KeyControlledItemList } from './KeyControlledList'
 const { array, func, object, string } = React.PropTypes
 
-@connect((state, props) => ({ choices: state.typeaheadMatches[props.typeaheadId] }))
+@connect((state, props) => ({ choices: state.typeaheadMatches[props.typeaheadId] }), null, null, {withRef: true})
 export default class PersonChooser extends React.Component {
 
   static propTypes = {
@@ -33,6 +33,10 @@ export default class PersonChooser extends React.Component {
 
   handleKeys = event => {
     if (this.refs.list) this.refs.list.handleKeys(event)
+  }
+  
+  focus () {
+    this.refs.input.focus()
   }
 
   select = choice => {

--- a/src/containers/DirectMessageModal.js
+++ b/src/containers/DirectMessageModal.js
@@ -9,16 +9,6 @@ import MessageToUserForm from '../components/MessageToUserForm'
 import PersonChooser from '../components/PersonChooser'
 const { func, object, string } = React.PropTypes
 
-const PersonPicker = (props) => {
-  const { onSelect, exclude } = props
-  const select = (person) => {
-    onSelect(person.id, person.name)
-  }
-  return <PersonChooser placeholder='Start typing a name...' onSelect={select}
-    typeaheadId='messageTo' exclude={exclude}/>
-}
-PersonPicker.propTypes = {onSelect: func, exclude: object}
-
 @connect((state, { userId }) => {
   return ({
     currentUser: get(state, 'people.current'),
@@ -39,18 +29,21 @@ export default class DirectMessageModal extends React.Component {
     const { dispatch } = this.context
     const { postId, userId } = this.props
     if (userId && !postId) dispatch(findOrCreateThread(userId))
+    if (!userId) this.refs.personChooser.getWrappedInstance().focus()
+    else this.refs.messageForm.getWrappedInstance().focus()
   }
 
-  onSelect (userId, userName) {
+  onSelect = (person) => {
     const { dispatch } = this.context
-    dispatch(showDirectMessage(userId, userName))
+    dispatch(showDirectMessage(person.id, person.name))
   }
 
   render () {
     const { onCancel, postId, userId, userName } = this.props
     const { dispatch, currentUser } = this.context
     const title = userId ? `You and ${userName}`
-      : <PersonPicker onSelect={this.onSelect.bind(this)} exclude={currentUser}/>
+      : <PersonChooser ref='personChooser' placeholder='Start typing a name...' onSelect={this.onSelect}
+          typeaheadId='messageTo' exclude={currentUser}/>
 
     const onComplete = () => {
       dispatch(navigate(threadUrl(postId)))
@@ -59,7 +52,7 @@ export default class DirectMessageModal extends React.Component {
     }
 
     return <Modal {...{title}} id='direct-message' onCancel={onCancel}>
-      <MessageToUserForm {...{userId, onComplete, postId}}/>
+      <MessageToUserForm ref='messageForm' {...{userId, onComplete, postId}}/>
     </Modal>
   }
 }


### PR DESCRIPTION
do this by bringing focus to the person select input immediately if there is no person chosen, and by bringing focus to the message input immediately if a person was chosen to begin with, or just selected via the personchooser

fixes https://trello.com/c/YbzTox8A/70-bring-text-field-into-focus-for-keyboard-input-when-the-dm-modal-with-a-person-pre-selected-opens