### PR TITLE
Improve request to join from logged out/unregistered flow

### DIFF
--- a/src/containers/Login.js
+++ b/src/containers/Login.js
@@ -127,7 +127,10 @@ export default class Login extends React.Component {
     const { actionError, location: { query }, community } = this.props
     const error = displayError(this.props.error)
     const signupUrl = makeUrl('/signup', pick(query, 'next', 'action', 'id', 'token', 'email'))
-    const { email } = query
+    const { email, next } = query
+    const willCreateJoinRequest = next && 
+      (next.indexOf('join=true') > -1 || next.indexOf('join%3Dtrue') > -1)
+    const subtitle = willCreateJoinRequest ? 'Once you log in, a request to join the community will be sent.' : ''
 
     const title = <span><div className='hylo-logo' />Log in to hylo</span>
 
@@ -137,7 +140,7 @@ export default class Login extends React.Component {
         <div className='medium-avatar' style={{backgroundImage: `url(${community.avatar_url})`}} />
         <h2>Join {community.name}</h2>
       </div>}
-      <Modal title={title} standalone>
+      <Modal title={title} subtitle={subtitle} standalone>
         <form onSubmit={this.submit}>
           {actionError && <div className='alert alert-danger'>{actionError}</div>}
           {error && <div className='alert alert-danger'>{error}</div>}

--- a/src/containers/Login.js
+++ b/src/containers/Login.js
@@ -130,7 +130,10 @@ export default class Login extends React.Component {
     const { email, next } = query
     const willCreateJoinRequest = next && 
       (next.indexOf('join=true') > -1 || next.indexOf('join%3Dtrue') > -1)
-    const subtitle = willCreateJoinRequest ? 'Once you log in, a request to join the community will be sent.' : ''
+    let subtitle = ''
+    if (willCreateJoinRequest) {
+      subtitle = 'Once you log in, a request to join the community will be sent.'
+    }
 
     const title = <span><div className='hylo-logo' />Log in to hylo</span>
 

--- a/src/containers/Signup.js
+++ b/src/containers/Signup.js
@@ -91,9 +91,13 @@ export default class Signup extends React.Component {
     const { email, next } = query
     const willCreateJoinRequest = next && 
       (next.indexOf('join=true') > -1 || next.indexOf('join%3Dtrue') > -1)
-    let subtitle = willCreateJoinRequest ? 'Once you sign up, a request to join the community will be sent.' : ''
-    subtitle = !community && !willCreateJoinRequest ? `If you're trying to join an existing community, please use the special
-        invitation link that you received from your community manager.` : subtitle
+    let subtitle = `If you're trying to join an existing community, please use the special
+        invitation link that you received from your community manager.`
+    if (willCreateJoinRequest) {
+      subtitle = 'Once you sign up, a request to join the community will be sent.'
+    } else if (community) {
+      subtitle = ''
+    }
         
     return <ModalOnlyPage id='signup' className='login-signup'>
       <div className='logo-wrapper'><div className='hylo-logo' /></div>

--- a/src/containers/Signup.js
+++ b/src/containers/Signup.js
@@ -88,15 +88,17 @@ export default class Signup extends React.Component {
 
     const { actionError, location: { query }, community } = this.props
     const loginUrl = makeUrl('/login', pick(query, 'next', 'action', 'id', 'token', 'email'))
-    const subtitle = community ? null
-      : `If you're trying to join an existing community, please use the special
-        invitation link that you received from your community manager.`
-    const { email } = query
-
+    const { email, next } = query
+    const willCreateJoinRequest = next && 
+      (next.indexOf('join=true') > -1 || next.indexOf('join%3Dtrue') > -1)
+    let subtitle = willCreateJoinRequest ? 'Once you sign up, a request to join the community will be sent.' : ''
+    subtitle = !community && !willCreateJoinRequest ? `If you're trying to join an existing community, please use the special
+        invitation link that you received from your community manager.` : subtitle
+        
     return <ModalOnlyPage id='signup' className='login-signup'>
       <div className='logo-wrapper'><div className='hylo-logo' /></div>
       <CommunityHeader community={community} />
-      <Modal title='Create your account.' subtitle={subtitle} standalone>
+      <Modal title='Create your account' subtitle={subtitle} standalone>
         <form onSubmit={this.submit}>
           {actionError && <div className='alert alert-danger'>{actionError}</div>}
           {error && <div className='alert alert-danger'>{error}</div>}


### PR DESCRIPTION
**How it looks now**
only when the url provides an indication that they arrived here via clicking 'request to join' community while unauthed.

![screen shot 2017-01-13 at 4 22 43 pm](https://cloud.githubusercontent.com/assets/1409121/21946038/96685042-d9ac-11e6-80b2-1cbd8a158da6.png)

![screen shot 2017-01-13 at 4 22 32 pm](https://cloud.githubusercontent.com/assets/1409121/21946040/98ac08ee-d9ac-11e6-9737-c33073d02cac.png)

![screen shot 2017-01-13 at 4 26 03 pm](https://cloud.githubusercontent.com/assets/1409121/21946133/053157da-d9ad-11e6-99d4-e7ec89883e95.png)

