### PR TITLE
fix refresh posts button positioning

### DIFF
--- a/css/layout.less
+++ b/css/layout.less
@@ -146,9 +146,13 @@
   }
 }
 
+.post-list-wrapper {
+  position: relative;
+}
+
 .refresh-button-container {
   position: absolute;
-  top: 127px;
+  top: 15px;
   left: 50%;
   margin-left: -@refresh-button-width/2;
 


### PR DESCRIPTION
the refresh button should be positioned according to the connected post list within which appears. the parent element needed `position: relative;` for this to work

**Broken**

![screen shot 2017-01-13 at 1 49 19 pm](https://cloud.githubusercontent.com/assets/1409121/21941535/2a120eca-d997-11e6-9f2a-490173a2a180.png)

**Fixed**

![screen shot 2017-01-13 at 1 41 54 pm](https://cloud.githubusercontent.com/assets/1409121/21941534/2a118fb8-d997-11e6-8c18-44ab14ce3c25.png)
