### PR TITLE
Fix long project names in project activity

### DIFF
--- a/css/posts.less
+++ b/css/posts.less
@@ -1313,6 +1313,12 @@ ul.posts {
     border-bottom: 2px solid @faint-gray-border;
     height: 80px;
     line-height: 80px;
+    display:flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-content: flex-start;
+    align-items: flex-start;
     .image {
       width: 50px;
       height: 50px;
@@ -1327,9 +1333,15 @@ ul.posts {
       color: @dark-gray-bg;
       margin-left: 20px;
       font-size: 20px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-basis: 200px;
     }
     .spacer {
-      margin: 0 3px;
+      margin: 0 6px;
       color: @dark-gray-bg;
       font-size: 14px;
     }
@@ -1338,6 +1350,7 @@ ul.posts {
       font-weight: 300;
       position: relative;
       top: -1px;
+      margin-right: 10px;
     }
     .orange-button {
       .round-button;

--- a/src/components/PostHeader.js
+++ b/src/components/PostHeader.js
@@ -69,20 +69,16 @@ const WelcomePostHeader = ({ person, community }) => {
   </div>
 }
 
-const AppearsIn = ({ community, communities, parentPost }) => {
+const AppearsIn = ({ community, communities }) => {
+  console.log('appears in')
   communities = communities || []
   if (community) communities = sortBy(communities, c => c.id !== community.id)
   const { length } = communities
-  if (length === 0 && !parentPost) return null
+  if (length === 0) return null
   const communityLink = community => <A to={`/c/${community.slug}`}>{community.name}</A>
-  const parentPostLink = parentPost => <span>
-    <A to={`/p/${parentPost.id}`} className='project-link'>{parentPost.name}</A>
-    {length > 0 && spacer}
-  </span>
 
   return <span className='communities'>
     &nbsp;in&nbsp;
-    {parentPost && parentPostLink(parentPost)}
     {length > 0 && communityLink(communities[0])}
     {length > 1 && <span> + </span>}
     {length > 1 &&

--- a/src/components/PostHeader.js
+++ b/src/components/PostHeader.js
@@ -70,7 +70,6 @@ const WelcomePostHeader = ({ person, community }) => {
 }
 
 const AppearsIn = ({ community, communities }) => {
-  console.log('appears in')
   communities = communities || []
   if (community) communities = sortBy(communities, c => c.id !== community.id)
   const { length } = communities


### PR DESCRIPTION
This fixes https://trello.com/c/oluOqQv7

![screen shot 2017-02-08 at 2 42 10 pm](https://cloud.githubusercontent.com/assets/891124/22758759/465a9950-ee0d-11e6-9ec2-7322c8e01a77.png)

Do we want to do anything about the project name in the post meta as well? Doesn't exactly break anything, but it's a little much. I took a shot at it and it's tricky and didn't want to go further down that rabbit hole unless we feel it's worthwhile.