### PR TITLE
(WIP) Adding comment to project activity

### DIFF
--- a/src/reducers/posts.js
+++ b/src/reducers/posts.js
@@ -107,8 +107,6 @@ export default function (state = {}, action) {
         updated_at: new Date().toISOString()
       })
     case CREATE_COMMENT:
-      // this is a temporary fix to a bug in creating comments for project activity posts
-      if (!post) return state
       return updatePostProps(state, id, {
         follower_ids: uniq((post.follower_ids || []).concat(payload.user_id)),
         numComments: (post.numComments || 0) + 1,


### PR DESCRIPTION
Relates to this issue: https://trello.com/c/mXkzyWFy
(which FYI is still just in the backlog)

@Connoropolous and @lorenjohnson this looks like an issue that was created when switching the nesting of project_activities from child > project to project > child.

Seeing this, I remembered why I did it child > project to begin with ;) Not saying switching was the wrong thing, but in the reducers we get back some of the complexity we saved in other places.