### PR TITLE
No popovers on mobile

### DIFF
--- a/src/containers/App/component.js
+++ b/src/containers/App/component.js
@@ -92,7 +92,7 @@ export default class App extends React.Component {
   render () {
     const {
       children, community, leftNavIsOpen, notifierMessages, openModals,
-      popover, currentUser, location, removeNotification
+      popover, currentUser, location, isMobile, removeNotification
     } = this.props
 
     const classes = cx({
@@ -104,6 +104,7 @@ export default class App extends React.Component {
 
     const { pathname } = location || {}
     const showIntercomButton = pathname && !pathname.startsWith('/t/')
+    const showPopover = !isEmpty(popover) && !isMobile
 
     return <div className={classes}>
       {children}
@@ -113,7 +114,7 @@ export default class App extends React.Component {
         remove={id => removeNotification(id)} />
       <LiveStatusPoller community={community} />
       <PageTitleController />
-      {!isEmpty(popover) && <Popover {...{popover}} />}
+      {showPopover && <Popover {...{popover}} />}
       {openModals.map((modal, i) =>
         <ModalWrapper key={i}
           bottom={i === 0}

--- a/src/containers/App/component.js
+++ b/src/containers/App/component.js
@@ -33,8 +33,12 @@ export default class App extends React.Component {
     popover: object
   }
 
+  static contextTypes = {
+    store: object.isRequired
+  }
+
   static childContextTypes = {
-    dispatch: func,
+    dispatch: func.isRequired,
     currentUser: object,
     isMobile: bool,
     location: object
@@ -47,8 +51,8 @@ export default class App extends React.Component {
 
   getChildContext () {
     const { currentUser, isMobile, location } = this.props
-    const { dispatch } = this.context
-    return { dispatch, currentUser, isMobile, location }
+    const { store } = this.context
+    return { dispatch: store.dispatch, currentUser, isMobile, location }
   }
 
   componentDidMount () {

--- a/src/containers/App/connector.js
+++ b/src/containers/App/connector.js
@@ -1,0 +1,45 @@
+import { prefetch } from 'react-fetcher'
+import { connect } from 'react-redux'
+import { compose } from 'redux'
+import { pick } from 'lodash'
+import { get } from 'lodash/fp'
+import {
+  removeNotification,
+  toggleLeftNav,
+  navigate,
+  notify,
+  setMobileDevice
+} from '../../actions'
+import { getCurrentCommunity } from '../../models/community'
+import { getCurrentNetwork } from '../../models/network'
+import { denormalizedCurrentUser } from '../../models/currentUser'
+
+function fetchToState ({ store, dispatch, currentUser }) {
+  const { isMobile } = store.getState()
+  if (!isMobile && typeof window === 'undefined' && currentUser &&
+    get('settings.leftNavIsOpen', currentUser) !== false) {
+    return dispatch(toggleLeftNav())
+  }
+}
+
+function mapStateToProps (state, { params }) {
+  return {
+    ...pick(state, 'isMobile', 'leftNavIsOpen', 'notifierMessages', 'openModals', 'popover'),
+    network: getCurrentNetwork(state),
+    community: getCurrentCommunity(state),
+    currentUser: denormalizedCurrentUser(state)
+  }
+}
+
+const mapDispatchToProps = {
+  removeNotification,
+  toggleLeftNav,
+  navigate,
+  notify,
+  setMobileDevice
+}
+
+export default compose(
+  prefetch(fetchToState),
+  connect(mapStateToProps, mapDispatchToProps, null, {withRef: true})
+)

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,0 +1,3 @@
+import component from './component'
+import connector from './connector'
+export default connector(component)

--- a/test/client/components/ShareTopicModal.test.js
+++ b/test/client/components/ShareTopicModal.test.js
@@ -2,8 +2,8 @@ require('../support')
 import React from 'react'
 import { mount } from 'enzyme'
 import { configureStore } from '../../../src/store'
-import App from '../../../src/containers/App.js'
-import ShareTopicModal from '../../../src/containers/ShareTopicModal.js'
+import App from '../../../src/containers/App'
+import ShareTopicModal from '../../../src/containers/ShareTopicModal'
 import {
   renderIntoDocument, findRenderedDOMComponentWithClass
 } from 'react-addons-test-utils'
@@ -12,7 +12,7 @@ import { keyMap } from '../../../src/util/textInput'
 
 describe('ShareTopicModal', () => {
   var store
-  const beta_access_code = 'foocode'
+  const beta_access_code = 'foocode' // eslint-disable-line camelcase
   const slug = 'foomunity'
   const tagName = 'bartag'
   const currentCommunityId = '1'
@@ -52,7 +52,7 @@ describe('ShareTopicModal', () => {
   })
 
   it('validates emails', () => {
-    const node = mount(<ShareTopicModal slug={slug}/>, {
+    const node = mount(<ShareTopicModal slug={slug} />, {
       context: {store}
     })
     const input = node.find('input[type="text"]')

--- a/test/components/App/component.test.js
+++ b/test/components/App/component.test.js
@@ -1,0 +1,44 @@
+import '../../support'
+import React from 'react'
+import { merge } from 'lodash'
+import { shallow } from 'enzyme'
+import App from '../../../src/containers/App/component'
+
+const minProps = {
+  removeNotification: () => {},
+  navigate: () => {},
+  notify: () => {},
+  setMobileDevice: () => {},
+  openModals: []
+}
+
+function renderComponent (props) {
+  return shallow(
+    <App {...merge(minProps, props)} />
+  )
+}
+
+describe('<App />', () => {
+  it('renders with minimum props', () => {
+    const wrapper = renderComponent()
+    expect(wrapper.find('div').length).to.equal(1)
+  })
+
+  it('renders child content', () => {
+    const props = {
+      children: <div className='test-content'>Child content is required</div>
+    }
+    const wrapper = renderComponent(props)
+    expect(wrapper.find('div.test-content').length).to.equal(1)
+  })
+
+  describe('with popover', () => {
+    it('renders when passed', () => {
+      const props = {
+        popover: {notempty: 'test'}
+      }
+      const wrapper = renderComponent(props)
+      expect(wrapper.find('Connect(Popover)').length).to.equal(1)
+    })
+  })
+})

--- a/test/components/App/component.test.js
+++ b/test/components/App/component.test.js
@@ -12,9 +12,16 @@ const minProps = {
   openModals: []
 }
 
+const minContext = {
+  store: {
+    dispatch: () => {}
+  }
+}
+
 function renderComponent (props) {
   return shallow(
-    <App {...merge(minProps, props)} />
+    <App {...merge(minProps, props)} />,
+    {context: minContext}
   )
 }
 

--- a/test/components/App/component.test.js
+++ b/test/components/App/component.test.js
@@ -40,5 +40,14 @@ describe('<App />', () => {
       const wrapper = renderComponent(props)
       expect(wrapper.find('Connect(Popover)').length).to.equal(1)
     })
+
+    it('does not render on mobile', () => {
+      const props = {
+        popover: {notempty: 'test'},
+        isMobile: true
+      }
+      const wrapper = renderComponent(props)
+      expect(wrapper.find('Connect(Popover)').length).to.equal(0)
+    })
   })
 })


### PR DESCRIPTION
1) Carrying forward with my intent to bring up whatever I touch I went ahead and pod'ified App and added very basic render tests, as well as coverage for this ticket.

    NOTE: As dispatch is no longer used internally in the component I've changed dispatch from being passed from props to childContext to context to childContext.

2) Handling the blocking of mobile rendering of the popover in App where the popover is rendered rather than adding an isMobile to every call of handle / showPopover. 

    This perhaps could be handled in the popover reducer, but I didn't see off-hand how to access isMobile in the state tree at the point of the popover reducer nor was I confident this would be idiomatic or better than what I've done. Happy to change it to any other way if there is a better way or a reason to not do it the way I've chosen. 


https://trello.com/c/cO2MOx5O
