### PR TITLE
Safer merge of min props in tests

### DIFF
--- a/test/client/components/Popover/component.test.js
+++ b/test/client/components/Popover/component.test.js
@@ -18,7 +18,7 @@ const minProps = {
 }
 
 function renderComponent (props) {
-  return shallow(<Popover {...merge(minProps, props)} />)
+  return shallow(<Popover {...merge({}, minProps, props)} />)
 }
 
 describe('<Popover />', () => {

--- a/test/components/App/component.test.js
+++ b/test/components/App/component.test.js
@@ -20,7 +20,7 @@ const minContext = {
 
 function renderComponent (props) {
   return shallow(
-    <App {...merge(minProps, props)} />,
+    <App {...merge({}, minProps, props)} />,
     {context: minContext}
   )
 }

--- a/test/components/Avatar/component.test.js
+++ b/test/components/Avatar/component.test.js
@@ -12,7 +12,7 @@ const minProps = {
 }
 
 function renderComponent (props) {
-  return shallow(<Avatar {...merge(minProps, props)} />)
+  return shallow(<Avatar {...merge({}, minProps, props)} />)
 }
 
 describe('<Avatar />', () => {

--- a/test/components/ClickCatcher/component.test.js
+++ b/test/components/ClickCatcher/component.test.js
@@ -10,7 +10,7 @@ const minProps = {
 }
 
 function renderComponent (props) {
-  return shallow(<ClickCatcher {...merge(minProps, props)} />)
+  return shallow(<ClickCatcher {...merge({}, minProps, props)} />)
 }
 
 describe('<ClickCatcher />', () => {

--- a/test/components/PersonCards.test.js
+++ b/test/components/PersonCards.test.js
@@ -12,7 +12,7 @@ const minProps = {
 }
 
 function renderComponent (props) {
-  return shallow(<PersonCards {...merge(minProps, props)} />)
+  return shallow(<PersonCards {...merge({}, minProps, props)} />)
 }
 
 describe('<PersonCards />', () => {

--- a/test/components/Post/component.test.js
+++ b/test/components/Post/component.test.js
@@ -17,7 +17,7 @@ const requiredContext = {
 }
 
 function renderComponent (props) {
-  return shallow(<Post {...merge(minProps, props)} />, {context: requiredContext})
+  return shallow(<Post {...merge({}, minProps, props)} />, {context: requiredContext})
 }
 
 describe('<Post />', () => {

--- a/test/components/PostDetails.js
+++ b/test/components/PostDetails.js
@@ -14,7 +14,7 @@ const requiredContext = {
 }
 
 function renderComponent (props) {
-  return shallow(<PostDetails {...merge(minProps, props)} />, {context: requiredContext})
+  return shallow(<PostDetails {...merge({}, minProps, props)} />, {context: requiredContext})
 }
 
 describe('<PostDetails />', () => {

--- a/test/components/PostList/component.test.js
+++ b/test/components/PostList/component.test.js
@@ -50,7 +50,7 @@ const minProps = {
 }
 
 function renderComponent (props) {
-  return shallow(<PostList {...merge(minProps, props)} />)
+  return shallow(<PostList {...merge({}, minProps, props)} />)
 }
 
 describe('<PostList />', () => {


### PR DESCRIPTION
Oops--in recent work I had a test failing due to an inline mutation of minProps, so I did a global look in the tests for the other cases where I/we neglected to resolve the lodash merge into a new object vs into minProps in the recently touched tests and fixed those cases.