### PR TITLE
fix invite styles for mobile especially

### DIFF
--- a/css/communities.less
+++ b/css/communities.less
@@ -58,6 +58,15 @@
 }
 
 #community-invite-form {
+  .community-invite-form-header {
+    font-size: 20px;
+    font-weight: 500;
+    padding-left: @modal-row-side-padding;
+    padding-right: @modal-row-side-padding;
+    border-top: 1px solid @post-border;
+    padding-top: 5px;
+  }
+
   input[type="file"] {
     display: none
   }
@@ -98,16 +107,24 @@
   }
 
   .moderator {
-    float: right;
+    margin-bottom: 10px;
     input {
-      position: relative;
-      top: 5px;
+      display: inline-block;
+      vertical-align: middle;
+      .mobile({
+        float: left;
+        display: block;
+      });
     }
     .meta{
       .meta-text;
       margin-left: 10px;
-      position: relative;
-      top: -5px;
+      display: inline-block;
+      .mobile({
+        margin-left: 42px;
+        display: block;
+        min-height: 32px;
+      });
     }
   }
 }
@@ -261,18 +278,15 @@
       label {
         font-size: 20px;
         font-weight: 500;
-        .count {
-          .meta-text;
-          margin-left: 10px;
-        }
+      }
+      .count {
+        .meta-text;
       }
       .resend-all {
         .round-button;
         color: @damian-green;
-        float: right;
         border: 1px solid @post-border;
-        position: relative;
-        top: -60px;
+        margin-bottom: 10px;
       }
 
     }
@@ -299,10 +313,8 @@
       .approve-all {
         .round-button;
         color: @damian-green;
-        float: right;
         border: 1px solid @post-border;
-        position: relative;
-        top: -60px;
+        margin-bottom: 10px;
       }
     }
   }

--- a/src/containers/InviteModal.js
+++ b/src/containers/InviteModal.js
@@ -60,11 +60,13 @@ export class InviteForm extends React.Component {
     invitationEditor: object,
     onClose: func,
     standalone: bool,
+    showHeader: bool,
     allowModerators: bool
   }
 
   static contextTypes = {
-    currentUser: object
+    currentUser: object,
+    isMobile: bool
   }
 
   constructor (props) {
@@ -112,9 +114,9 @@ export class InviteForm extends React.Component {
   render () {
     const { expanded } = this.state
     const {
-      dispatch, invitationEditor, community, onClose, standalone, allowModerators
+      dispatch, invitationEditor, community, onClose, standalone, showHeader, allowModerators
     } = this.props
-    const { currentUser } = this.context
+    const { currentUser, isMobile } = this.context
 
     if (!canInvite(currentUser, community)) {
       return <AccessErrorMessage error={{status: 403}} />
@@ -163,14 +165,17 @@ export class InviteForm extends React.Component {
     }
 
     return <span id='community-invite-form'>
-      <div className='modal-input csv-upload'>
+      {showHeader && <label className='community-invite-form-header'>
+        Send Email Invitations
+      </label>}
+      {!isMobile && <div className='modal-input csv-upload'>
         <label className='custom-file-upload'>
           <input type='file' onChange={() => this.processCSV()} ref='fileInput' />
           Upload CSV
         </label>
         <label className='normal-label'>Import CSV File (optional)</label>
         <p className='help-text'>The file should have a header row named "email" for the email column. Or it can be a file in which each line is a single email address.</p>
-      </div>
+      </div>}
       <ModalInput
         className='emails'
         ref='emails'
@@ -199,12 +204,12 @@ export class InviteForm extends React.Component {
         onChange={update('message')} />}
       {error && <div className='alert alert-danger'>{error}</div>}
       <div className='footer'>
+        {allowModerators && canModerate(currentUser, community) && <div className='moderator'>
+          <input type='checkbox' checked={moderator} onChange={update('moderator', true)} />
+          <div className='meta'>Check to invite these people to be moderators of the community.</div>
+        </div>}
         <a className='button ok' onClick={submit}>Invite</a>
         {standalone && <A to={checklistUrl(community)} onClick={clearEditor} className='skip'>Skip</A>}
-        {allowModerators && canModerate(currentUser, community) && <span className='moderator'>
-          <input type='checkbox' checked={moderator} onChange={update('moderator', true)} />
-          <span className='meta'>Check to invite these people to be moderators of the community.</span>
-        </span>}
       </div>
     </span>
   }

--- a/src/containers/community/CommunityInvite.js
+++ b/src/containers/community/CommunityInvite.js
@@ -79,7 +79,7 @@ export default class CommunityInvite extends React.Component {
         <a className='invitation-link' href={joinUrl}>{joinUrl}</a>
       </div>
       <div>
-        <InviteForm community={community} allowModerators />
+        <InviteForm community={community} allowModerators showHeader />
       </div>
       {hasFeature(currentUser, REQUEST_TO_JOIN_COMMUNITY) && !isEmpty(joinRequests) &&
         <JoinRequestList id={community.slug} />}

--- a/src/containers/community/InvitationList.js
+++ b/src/containers/community/InvitationList.js
@@ -49,7 +49,8 @@ const InvitationList = connect((state, { id }) => ({
     })
   return <div className='invitations'>
     <div className='invitations-header'>
-      <label>Pending Invitations <span className='count'>{countText}</span></label>
+      <label>Pending Invitations</label>
+      <p className='count'>{countText}</p>
       <p className='summary'>These are people you have already sent invitations to.</p>
       <a className='resend-all' onClick={resendAll}>Resend All</a>
     </div>

--- a/src/containers/community/JoinRequestList.js
+++ b/src/containers/community/JoinRequestList.js
@@ -39,7 +39,7 @@ const JoinRequestList = connect((state, { id }) => ({
   return <div className='join-requests'>
     <a name='join_requests' />
     <div className='join-requests-header'>
-      <label>Requests<span className='count'>{total}</span></label>
+      <label>Join Requests <span className='count'>{total}</span></label>
       <p className='summary'>These are people who have asked to join.</p>
       <a className='approve-all' onClick={approveAll}>Approve All</a>
     </div>


### PR DESCRIPTION
We were trying to do some special stuff for the web layout as distinct from the mobile layout but there were some holes in the idea, so I think the shortest route to utility and cleanliness here is just to resort back to some simplistic positioning on these elements. 

I hid the CSV import when you're on mobile. I don't think there's a use case for it.

![screenshot 2017-02-28 at 11 40 36 pm](https://cloud.githubusercontent.com/assets/1409121/23446296/05e63222-fe10-11e6-8ebf-7ec8efc417be.png)
![screenshot-hylo-redux-connoropolous c9users io 2017-02-28 23-25-00](https://cloud.githubusercontent.com/assets/1409121/23446299/105c47be-fe10-11e6-94bc-8d183bbdc0ac.png)
