### PR TITLE
Fix realtime comments on posts

### DIFF
--- a/css/posts.less
+++ b/css/posts.less
@@ -363,6 +363,7 @@ ul.posts {
     .typing {
       color: @faint-gray-text;
       padding-top: 10px;
+      padding-left: @post-content-left-margin;
       > div {
         display: inline-block;
       }

--- a/src/components/CommentSection.js
+++ b/src/components/CommentSection.js
@@ -33,8 +33,7 @@ export default class CommentSection extends React.Component {
     if (expanded) {
       this.socket = getSocket()
       this.socket.post(socketUrl(`/noo/post/${id}/subscribe`))
-      this.socket.on('commentAdded', ({ parent_post_id, comment }) => {
-        if (parent_post_id !== post.parent_post_id) return
+      this.socket.on('commentAdded', ({ comment }) => {
         if (comment.user_id === currentUser.id) return
         dispatch(appendComment(id, comment))
       })


### PR DESCRIPTION
most of the time this line
`if (parent_post_id !== post.parent_post_id) return`
was executing as `null !== undefined` which returns true which forces the function to return here, instead of displaying the comment. 
@robbiecarlton I tried to reason through this thinking about parent posts, but couldn't find a scenario to be concerned about. am I forgetting something?

goes with https://github.com/Hylozoic/hylo-node/pull/228