### PR TITLE
fix circumstance where newMessageCount wouldn't increment right

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -183,7 +183,7 @@ export function updatePostReadTime (id) {
 
 export function fetchPosts (opts) {
   const {
-    subject, id, limit, type, tag, sort, search, filter, cacheId, omit
+    subject, id, limit, type, tag, sort, search, filter, cacheId, omit, refresh
   } = opts
   const offset = opts.offset || 0
   const queryParams = {
@@ -232,7 +232,7 @@ export function fetchPosts (opts) {
     type: FETCH_POSTS,
     payload: {api: true, path},
     meta: {
-      cache: {id: cacheId, bucket: 'postsByQuery', limit, offset, array: true},
+      cache: {id: cacheId, bucket: 'postsByQuery', limit, offset, array: true, refresh},
       addDataToStore: {
         people: get('people'),
         communities: get('communities')

--- a/src/containers/ThreadsDropdown.js
+++ b/src/containers/ThreadsDropdown.js
@@ -113,12 +113,13 @@ export default class ThreadsDropdown extends React.Component {
       this.initialFetchThreads(true)
     } else {
       dispatch(appendComment(postId, message))
-      const updatedThreads = map(t => t.id === postId ? { ...t, updated_at: message.created_at } : t, threads)
+      const updatedThreads = map(t => t.id === postId ? { ...t, comments: (t.comments || []).concat([message]) } : t, threads)
       this.setUnseen(updatedThreads, lastViewed)
     }
   }
 
   initialFetchThreads (setUnseen) {
+    const { lastViewed } = this.props
     const { dispatch } = this.context
     dispatch(fetchPosts({cacheId: 'threads', subject: 'threads', refresh: true}))
     .then(({ payload }) => {

--- a/src/containers/ThreadsDropdown.js
+++ b/src/containers/ThreadsDropdown.js
@@ -74,7 +74,7 @@ export default class ThreadsDropdown extends React.Component {
       this.socket.on('messageAdded', this.messageAdded)
 
       this.reconnectHandler = () => {
-        // TODO clear cache in dropdown
+        this.initialFetchThreads(true)
         this.socket.post(socketUrl('/noo/threads/subscribe'))
       }
       this.socket.on('reconnect', this.reconnectHandler)
@@ -109,14 +109,21 @@ export default class ThreadsDropdown extends React.Component {
 
     if (this.state.open || thisThreadOpen) return dispatch(appendComment(postId, message))
 
-    if (!threads.length) { // or you don't have the thread in question?
-      dispatch(fetchPosts({cacheId: 'threads', subject: 'threads'}))
-      .then(({ payload }) => this.setUnseen(payload.posts, lastViewed))
+    if (!threads.length) {
+      this.initialFetchThreads(true)
     } else {
       dispatch(appendComment(postId, message))
       const updatedThreads = map(t => t.id === postId ? { ...t, updated_at: message.created_at } : t, threads)
       this.setUnseen(updatedThreads, lastViewed)
     }
+  }
+
+  initialFetchThreads (setUnseen) {
+    const { dispatch } = this.context
+    dispatch(fetchPosts({cacheId: 'threads', subject: 'threads', refresh: true}))
+    .then(({ payload }) => {
+      if (setUnseen && !this.state.open) this.setUnseen(payload.posts, lastViewed)
+    })
   }
 
   render () {
@@ -135,7 +142,7 @@ export default class ThreadsDropdown extends React.Component {
     }
 
     return <Dropdown alignRight rivalrous='nav' className='thread-list'
-      onFirstOpen={() => dispatch(fetchPosts({cacheId: 'threads', subject: 'threads'}))}
+      onFirstOpen={() => this.initialFetchThreads(false)}
       onOpen={onOpen}
       onClose={onClose}
       toggleChildren={<span>

--- a/src/util/threads.js
+++ b/src/util/threads.js
@@ -2,7 +2,7 @@ import { countBy, some } from 'lodash'
 
 export const unseenThreadCount = (threads, last_viewed_messages_at) => {
   const unread = t =>
-    threadIsUnnoticed(t, last_viewed_messages_at) && threadIsUnread(t)
+    t.comments && threadIsUnnoticed(t, last_viewed_messages_at) && threadIsUnread(t)
   return threads.filter(unread).length
 }
 

--- a/src/util/threads.js
+++ b/src/util/threads.js
@@ -1,4 +1,4 @@
-import { countBy } from 'lodash'
+import { countBy, some } from 'lodash'
 
 export const unseenThreadCount = (threads, last_viewed_messages_at) => {
   const unread = t =>
@@ -7,7 +7,7 @@ export const unseenThreadCount = (threads, last_viewed_messages_at) => {
 }
 
 export const threadIsUnnoticed = (thread, last_viewed_messages_at) =>
-  new Date(last_viewed_messages_at) < new Date(thread.updated_at)
+  some(thread.comments, c => new Date(last_viewed_messages_at) < new Date(c.created_at))
 
 export const threadIsUnread = thread =>
-  new Date(thread.last_read_at) < new Date(thread.updated_at)
+  some(thread.comments, c => new Date(thread.last_read_at) < new Date(c.created_at))


### PR DESCRIPTION
the reason we're unable to rely on post.updated_at for the latest comment time in these circumstances is the because the Post record is updated asynchronously by the worker now, after the comment has already been fully created, and the websocket events sent

this PR also handles an improvement to the way it handles things after socket reconnection, so that you will see a newMessageCount if there is one