### PR TITLE
Highlight preview close button

### DIFF
--- a/css/posts.less
+++ b/css/posts.less
@@ -133,11 +133,23 @@ ul.posts {
 
     .close {
       position: absolute;
-      right: 0;
+      right: 5px;
+      top: 5px;
       width: 20px;
+      height: 20px;
       text-align: center;
+      border-radius: 50%;
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+
+    &:hover {
+      .close {
+        background-color: rgba(255, 255, 255, 0.5);
+      }
     }
   }
+
+  
 
   .link-preview-title {
     display: block;


### PR DESCRIPTION
https://trello.com/c/n0uRGjj1/147-2-redux-allow-removal-of-a-link-preview-when-editing-a-post

- adds some background-color to make the button a little more visible against dark images