### PR TITLE
use horizontal scrolling for overflow of sections on people profile

### DIFF
--- a/css/people.less
+++ b/css/people.less
@@ -246,6 +246,7 @@
     .mobile({
       white-space: nowrap;
       overflow-x: scroll;
+      padding: 0 10px;
       a {
         width: auto;
         padding: 0 6px;

--- a/css/people.less
+++ b/css/people.less
@@ -243,6 +243,19 @@
         width: 20%;
       }
     }
+    .mobile({
+      white-space: nowrap;
+      overflow-x: scroll;
+      a {
+        width: auto;
+        padding: 0 6px;
+      }
+      &.contributions-feature {
+        a {
+          width: auto;
+        }
+      }
+    });
   }
 
   .section-label {

--- a/src/containers/person/PersonProfile.js
+++ b/src/containers/person/PersonProfile.js
@@ -145,6 +145,12 @@ const PersonProfile = compose(
     }
   }
 
+  let sectionLinks
+  const scrollIntoView = (e) => {
+    if (sectionLinks.firstChild === e.target) sectionLinks.scrollLeft = 0
+    else if (sectionLinks.lastChild === e.target) sectionLinks.scrollLeft = e.target.offsetLeft
+  }
+
   return <CoverImagePage id='person' image={banner_url || defaultBanner}
     person={isSelf ? currentUser : null}>
     <div className='opener'>
@@ -178,7 +184,8 @@ const PersonProfile = compose(
         #{tag}
       </A>)}
     </div>}
-    <div className={`section-links ${hasFeature(currentUser, CONTRIBUTORS) ? 'contributions-feature' : ''}`}>
+    <div className={`section-links ${hasFeature(currentUser, CONTRIBUTORS) ? 'contributions-feature' : ''}`}
+         ref={div => sectionLinks = div} onClick={scrollIntoView}>
       <TabLink category='offer' count={offerCount} />
       <TabLink category='request' count={requestCount} />
       <TabLink category='thank' count={person.thank_count} />
@@ -222,7 +229,7 @@ const setupTabLink = (props) => {
     if (isActive) { cssClasses.push('active') }
     const toggle = () =>
       dispatch(refetch({show: isActive ? null : category}, location))
-    return <a className={cssClasses} onClick={toggle}>
+    return <a className={cssClasses.join(' ')} onClick={toggle}>
       {count} {capitalize(category)}{Number(count) === 1 ? '' : 's'}
     </a>
   }


### PR DESCRIPTION
fixes https://trello.com/c/9RmST07w

see how it looks/works here: https://youtu.be/0V7McjosifY

also fixes a small bug where the active item wasn't getting the proper class attached to it to show as active

this works similar to how the header on github repos works on mobile